### PR TITLE
feat: månedlig Slack-rapport for avslutting av rinasaker (#16)

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -75,7 +75,10 @@ spec:
         - application: {{ application.eux-avslutt-rinasaker-arkiver-naisjob.name }}
         - application: {{ application.eux-avslutt-rinasaker-til-arkivering-naisjob.name }}
         - application: {{ application.eux-avslutt-rinasaker-slett-dokumentutkast-naisjob.name }}
+        - application: {{ application.eux-avslutt-rinasaker-rapport-naisjob.name }}
     outbound:
+      external:
+        - host: hooks.slack.com
       rules:
         - application: {{ application.eux-rina-terminator-api.name }}
   env:
@@ -88,3 +91,5 @@ spec:
       value: {{ application.eux-rina-terminator-api.endpoint }}
     - name: EUX_RINA_TERMINATOR_API_SCOPE
       value: {{ application.eux-rina-terminator-api.scope }}
+  envFrom:
+    - secret: slack-team-eessi-nav-driftsoppfolging-webhook

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -38,3 +38,6 @@ application:
 
   eux-avslutt-rinasaker-slett-dokumentutkast-naisjob:
     name: eux-avslutt-rinasaker-slett-dok-utkast-naisjob
+
+  eux-avslutt-rinasaker-rapport-naisjob:
+    name: eux-avslutt-rinasaker-rapport-naisjob

--- a/.nais/q1.yaml
+++ b/.nais/q1.yaml
@@ -38,3 +38,6 @@ application:
 
   eux-avslutt-rinasaker-slett-dokumentutkast-naisjob:
     name: eux-avslutt-rinasaker-slett-dok-utkast-naisjob-q1
+
+  eux-avslutt-rinasaker-rapport-naisjob:
+    name: eux-avslutt-rinasaker-rapport-naisjob-q1

--- a/.nais/q2.yaml
+++ b/.nais/q2.yaml
@@ -38,3 +38,6 @@ application:
 
   eux-avslutt-rinasaker-slett-dokumentutkast-naisjob:
     name: eux-avslutt-rinasaker-slett-dok-utkast-naisjob-q2
+
+  eux-avslutt-rinasaker-rapport-naisjob:
+    name: eux-avslutt-rinasaker-rapport-naisjob-q2

--- a/src/main/kotlin/no/nav/eux/avslutt/rinasaker/integration/SlackClient.kt
+++ b/src/main/kotlin/no/nav/eux/avslutt/rinasaker/integration/SlackClient.kt
@@ -1,0 +1,29 @@
+package no.nav.eux.avslutt.rinasaker.integration
+
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+
+@Service
+class SlackClient(
+    @Value("\${slack.webhooks.driftsoppfolging}")
+    val webhookEndpoint: String
+) {
+
+    val log = logger {}
+
+    fun post(text: String) {
+        val response = RestClient.create()
+            .post()
+            .uri(webhookEndpoint)
+            .contentType(APPLICATION_JSON)
+            .body(SlackMessage(text))
+            .retrieve()
+            .toEntity(String::class.java)
+        log.info { "Slack message sent: ${response.body}" }
+    }
+
+    data class SlackMessage(val text: String)
+}

--- a/src/main/kotlin/no/nav/eux/avslutt/rinasaker/persistence/repository/RinasakRepository.kt
+++ b/src/main/kotlin/no/nav/eux/avslutt/rinasaker/persistence/repository/RinasakRepository.kt
@@ -21,4 +21,29 @@ interface RinasakRepository : JpaRepository<Rinasak, UUID> {
         bucType: String,
         endretTidspunkt: LocalDateTime
     ): List<Rinasak>
+
+    fun countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(
+        status: Rinasak.Status,
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ): Long
+
+    fun findAllByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(
+        status: Rinasak.Status,
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ): List<Rinasak>
+
+    fun findAllByStatusInAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(
+        statuses: List<Rinasak.Status>,
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ): List<Rinasak>
+
+    fun countByOpprettetTidspunktGreaterThanEqualAndOpprettetTidspunktLessThan(
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ): Long
+
+    fun countByStatus(status: Rinasak.Status): Long
 }

--- a/src/main/kotlin/no/nav/eux/avslutt/rinasaker/service/RapportService.kt
+++ b/src/main/kotlin/no/nav/eux/avslutt/rinasaker/service/RapportService.kt
@@ -1,0 +1,143 @@
+package no.nav.eux.avslutt.rinasaker.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
+import no.nav.eux.avslutt.rinasaker.model.entity.Rinasak
+import no.nav.eux.avslutt.rinasaker.model.entity.Rinasak.Status.*
+import no.nav.eux.avslutt.rinasaker.persistence.repository.RinasakRepository
+import org.springframework.stereotype.Service
+import java.text.NumberFormat
+import java.time.LocalDateTime
+import java.time.format.TextStyle
+import java.util.*
+
+@Service
+class RapportService(
+    val repository: RinasakRepository,
+    val slackService: SlackService
+) {
+
+    val log = logger {}
+
+    val numberFormat: NumberFormat = NumberFormat.getInstance(Locale.of("nb", "NO"))
+
+    fun sendRapport() {
+        val now = LocalDateTime.now()
+        val forrigeMaanedStart = now.minusMonths(1).withDayOfMonth(1).toLocalDate().atStartOfDay()
+        val denneMaanedStart = now.withDayOfMonth(1).toLocalDate().atStartOfDay()
+        val maanedNavn = forrigeMaanedStart.month
+            .getDisplayName(TextStyle.FULL, Locale.of("nb", "NO"))
+            .replaceFirstChar { it.titlecase() }
+        val aar = forrigeMaanedStart.year
+        val melding = buildString {
+            append("*Månedlig rapport — Avslutt Rinasaker*\n")
+            append("_${maanedNavn} ${aar}_\n")
+            appendOppsummering(forrigeMaanedStart, denneMaanedStart)
+            appendTopp3BucTyper(forrigeMaanedStart, denneMaanedStart)
+            appendFeiledeSaker(forrigeMaanedStart, denneMaanedStart)
+            appendNaaværendeStatus()
+        }
+        log.info { melding }
+        slackService.post(melding)
+    }
+
+    private fun StringBuilder.appendOppsummering(
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ) {
+        val nyeSaker = repository.countByOpprettetTidspunktGreaterThanEqualAndOpprettetTidspunktLessThan(fra, til)
+        val avsluttetGlobalt = repository.countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(AVSLUTTET_GLOBALT, fra, til)
+        val avsluttetLokalt = repository.countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(AVSLUTTET_LOKALT, fra, til)
+        val arkivert = repository.countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(ARKIVERT, fra, til)
+        val feilet = repository.countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(HANDLING_FEILET, fra, til) +
+                repository.countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(HANDLING_MANGLER, fra, til)
+        val avsluttesAvMotpart = repository.countByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(AVSLUTTES_AV_MOTPART, fra, til)
+        append("\n📊 *Oppsummering forrige måned:*\n")
+        append("• Nye saker mottatt: `${fmt(nyeSaker)}`\n")
+        append("• Avsluttet globalt: `${fmt(avsluttetGlobalt)}`\n")
+        append("• Avsluttet lokalt: `${fmt(avsluttetLokalt)}`\n")
+        append("• Arkivert: `${fmt(arkivert)}`\n")
+        if (feilet > 0) append("• Feilet: `${fmt(feilet)}`\n")
+        if (avsluttesAvMotpart > 0) append("• Avsluttes av motpart: `${fmt(avsluttesAvMotpart)}`\n")
+    }
+
+    private fun StringBuilder.appendTopp3BucTyper(
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ) {
+        val avsluttetGlobaltSaker = repository.findAllByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(AVSLUTTET_GLOBALT, fra, til)
+        val avsluttetLokaltSaker = repository.findAllByStatusAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(AVSLUTTET_LOKALT, fra, til)
+
+        data class BucStats(val globalt: Long, val lokalt: Long) {
+            val totalt get() = globalt + lokalt
+        }
+
+        val bucStats = mutableMapOf<String, BucStats>()
+        avsluttetGlobaltSaker.groupBy { it.bucType }.forEach { (bucType, saker) ->
+            bucStats[bucType] = BucStats(globalt = saker.size.toLong(), lokalt = 0)
+        }
+        avsluttetLokaltSaker.groupBy { it.bucType }.forEach { (bucType, saker) ->
+            val existing = bucStats[bucType]
+            bucStats[bucType] = BucStats(
+                globalt = existing?.globalt ?: 0,
+                lokalt = saker.size.toLong()
+            )
+        }
+
+        if (bucStats.isEmpty()) return
+
+        val sorted = bucStats.entries.sortedByDescending { it.value.totalt }
+        val topp3 = sorted.take(3)
+        val ovrige = sorted.drop(3).sumOf { it.value.totalt }
+
+        append("\n📈 *Topp 3 BUC-typer — Avsluttet:*\n")
+        topp3.forEach { (bucType, stats) ->
+            append("• `$bucType`:  `${fmt(stats.globalt)}` globalt · `${fmt(stats.lokalt)}` lokalt\n")
+        }
+        if (ovrige > 0) {
+            append("• _Øvrige: `${fmt(ovrige)}` avsluttet totalt_\n")
+        }
+    }
+
+    private fun StringBuilder.appendFeiledeSaker(
+        fra: LocalDateTime,
+        til: LocalDateTime
+    ) {
+        val feiledeSaker = repository.findAllByStatusInAndEndretTidspunktGreaterThanEqualAndEndretTidspunktLessThan(
+            listOf(HANDLING_FEILET, HANDLING_MANGLER), fra, til
+        )
+        if (feiledeSaker.isEmpty()) return
+
+        append("\n❌ *Feilede saker:*\n")
+        feiledeSaker.take(10).forEach { sak ->
+            append("• `${sak.rinasakId}` — `${sak.bucType}` — ${sak.status}\n")
+        }
+        if (feiledeSaker.size > 10) {
+            append("_Totalt: `${fmt(feiledeSaker.size.toLong())}` feilede saker denne måneden_\n")
+        }
+    }
+
+    private fun StringBuilder.appendNaaværendeStatus() {
+        data class StatusLinje(val label: String, val count: Long)
+
+        val linjer = listOf(
+            StatusLinje("Nye saker (NY_SAK)", repository.countByStatus(NY_SAK)),
+            StatusLinje("Uvirksomme", repository.countByStatus(UVIRKSOM)),
+            StatusLinje("Til avslutning",
+                repository.countByStatus(TIL_AVSLUTNING_GLOBALT) +
+                        repository.countByStatus(TIL_AVSLUTNING_LOKALT)),
+            StatusLinje("Til arkivering", repository.countByStatus(TIL_ARKIVERING)),
+            StatusLinje("Feilet",
+                repository.countByStatus(HANDLING_FEILET) +
+                        repository.countByStatus(HANDLING_MANGLER)),
+        ).filter { it.count > 0 }
+
+        if (linjer.isEmpty()) return
+
+        append("\n📋 *Nåværende status:*\n")
+        linjer.forEach { (label, count) ->
+            append("• $label: `${fmt(count)}`\n")
+        }
+    }
+
+    private fun fmt(n: Long) = numberFormat.format(n)
+}

--- a/src/main/kotlin/no/nav/eux/avslutt/rinasaker/service/SlackService.kt
+++ b/src/main/kotlin/no/nav/eux/avslutt/rinasaker/service/SlackService.kt
@@ -1,0 +1,29 @@
+package no.nav.eux.avslutt.rinasaker.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
+import no.nav.eux.avslutt.rinasaker.integration.SlackClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class SlackService(
+    val slackClient: SlackClient,
+    @Value("\${NAIS_APP_NAME:avslutt-rinasaker}")
+    appName: String
+) {
+
+    val log = logger {}
+
+    val environment: String = when {
+        appName.endsWith("q1") -> "q1"
+        appName.endsWith("q2") -> "q2"
+        else -> "prod"
+    }
+
+    fun post(tekst: String) =
+        try {
+            slackClient.post("`[$environment]` `[avslutt-rinasaker]` $tekst")
+        } catch (e: RuntimeException) {
+            log.error(e) { "Feilet å sende Slack-melding: $tekst" }
+        }
+}

--- a/src/main/kotlin/no/nav/eux/avslutt/rinasaker/webapp/AvsluttRinasakerApi.kt
+++ b/src/main/kotlin/no/nav/eux/avslutt/rinasaker/webapp/AvsluttRinasakerApi.kt
@@ -27,7 +27,8 @@ class AvsluttRinasakerApi(
     val avsluttService: AvsluttService,
     val arkiverService: ArkiverService,
     val tilArkiveringService: TilArkiveringService,
-    val slettDokumentutkastService: SlettDokumentutkastService
+    val slettDokumentutkastService: SlettDokumentutkastService,
+    val rapportService: RapportService
 ) {
 
     val log = logger {}
@@ -78,6 +79,7 @@ class AvsluttRinasakerApi(
                     * `til-arkivering` - Setter rinasaker til arkivering
                     * `arkiver` - Arkiverer rinasaker
                     * `slett-dokumentutkast` - Sletter dokumentutkast for X001
+                    * `rapport` - Sender månedlig Slack-rapport
                     """,
             required = true
         )
@@ -93,6 +95,7 @@ class AvsluttRinasakerApi(
             "til-arkivering" -> tilArkiveringService.settRinasakerTilArkivering()
             "arkiver" -> arkiverService.arkiverRinasaker()
             "slett-dokumentutkast" -> slettDokumentutkastService.slettDokumentutkast()
+            "rapport" -> rapportService.sendRapport()
             else -> {
                 log.error { "ukjent prosess: $prosess" }
                 return ResponseEntity(BAD_REQUEST)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,4 +66,8 @@ no.nav.security.jwt:
           client-jwk: ${AZURE_APP_JWK}
           client-auth-method: private_key_jwt
 
+slack:
+  webhooks:
+    driftsoppfolging: ${SLACK_WEBHOOK_DRIFTSOPPFOLGING:}
+
 logging.level.org.hibernate.orm.connections.pooling: warn

--- a/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/AvsluttRinasakerTest.kt
+++ b/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/AvsluttRinasakerTest.kt
@@ -37,6 +37,8 @@ class AvsluttRinasakerTest : AbstractTest() {
         execute(prosess = "arkiver")
         verifiserArkivertStatus()
         verifiserArkivertKall()
+        sendRapport()
+        verifiserRapportSendt()
     }
 
     fun isRunning() {
@@ -180,5 +182,17 @@ class AvsluttRinasakerTest : AbstractTest() {
         verifiserEksekvert("/api/v1/rinasaker/5/arkiver")
         verifiserEksekvert("/api/v1/rinasaker/9/arkiver")
         verifiserEksekvert("/api/v1/rinasaker/10/arkiver")
+    }
+
+    fun sendRapport() {
+        execute(prosess = "rapport")
+    }
+
+    fun verifiserRapportSendt() {
+        val rapportBody = requestBodies["/slack/webhook"]
+        assertThat(rapportBody).isNotNull()
+        assertThat(rapportBody).contains("Månedlig rapport")
+        assertThat(rapportBody).contains("Oppsummering forrige måned")
+        assertThat(rapportBody).contains("Nåværende status")
     }
 }

--- a/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/mock/MockResponses.kt
+++ b/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/mock/MockResponses.kt
@@ -29,6 +29,7 @@ fun mockResponsePost(request: RecordedRequest) =
         "/api/v1/rinasaker/8/arkiver" -> getEuxRinaTerminatorApiNoContent()
         "/api/v1/rinasaker/9/arkiver" -> getEuxRinaTerminatorApiNoContent()
         "/api/v1/rinasaker/10/arkiver" -> getEuxRinaTerminatorApiNoContent()
+        "/slack/webhook" -> slackWebhookResponse()
         else -> defaultResponse()
     }
 

--- a/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/mock/MockResponsesSlack.kt
+++ b/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/mock/MockResponsesSlack.kt
@@ -1,0 +1,12 @@
+package no.nav.eux.avslutt.rinasaker.webapp.mock
+
+import okhttp3.mockwebserver.MockResponse
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.MediaType.TEXT_PLAIN_VALUE
+
+fun slackWebhookResponse() =
+    MockResponse().apply {
+        setResponseCode(200)
+        setHeader(CONTENT_TYPE, TEXT_PLAIN_VALUE)
+        setBody("ok")
+    }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -20,6 +20,10 @@ no.nav.security.jwt:
 endpoint:
   eux-rina-terminator-api: http://localhost:9500/mock
 
+slack:
+  webhooks:
+    driftsoppfolging: http://localhost:9500/mock/slack/webhook
+
 kafka:
   topics:
     eux-rina-document-events-v1: eessibasis.eux-rina-document-events-v1


### PR DESCRIPTION
Add monthly Slack reporting with summary statistics, top 3 BUC types,
failed cases, and current queue status.

New files:
- SlackClient.kt: HTTP POST to Slack webhook
- SlackService.kt: environment-aware wrapper with error handling
- RapportService.kt: builds and sends formatted report

Changes:
- RinasakRepository: new count/find methods for date-range queries
- AvsluttRinasakerApi: added 'rapport' process endpoint
- application.yml: slack webhook configuration
- NAIS configs: outbound hooks.slack.com, webhook secret, rapport naisjob

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
