### PR TITLE
Erstatt TestRestTemplate med RestTestClient i tester

### DIFF
--- a/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/common/AbstractTest.kt
+++ b/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/common/AbstractTest.kt
@@ -9,16 +9,14 @@ import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.assertj.core.api.Assertions.assertThat
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.resttestclient.TestRestTemplate
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
-import org.springframework.boot.resttestclient.exchange
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpMethod.POST
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.client.RestTestClient
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.kafka.KafkaContainer
@@ -34,7 +32,7 @@ import kotlin.test.assertEquals
 @EnableMockOAuth2Server
 @Testcontainers
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 abstract class AbstractTest {
 
     companion object {
@@ -60,13 +58,11 @@ abstract class AbstractTest {
         }
     }
 
-    fun httpEntity() = voidHttpEntity(mockOAuth2Server)
-
     @Autowired
     lateinit var mockOAuth2Server: MockOAuth2Server
 
     @Autowired
-    lateinit var restTemplate: TestRestTemplate
+    lateinit var restTestClient: RestTestClient
 
     @Autowired
     @Suppress("SpringJavaInjectionPointsAutowiringInspection")
@@ -82,12 +78,11 @@ abstract class AbstractTest {
     lateinit var requestBodies: RequestBodies
 
     fun execute(prosess: String) {
-        restTemplate
-            .exchange<Void>(
-                "/api/v1/prosesser/$prosess/execute",
-                POST,
-                httpEntity()
-            )
+        restTestClient
+            .post()
+            .uri("/api/v1/prosesser/$prosess/execute")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
     }
 
     infix fun Int.er(expected: Status) {

--- a/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/common/HttpEntity.kt
+++ b/src/test/kotlin/no/nav/eux/avslutt/rinasaker/webapp/common/HttpEntity.kt
@@ -3,20 +3,6 @@ package no.nav.eux.avslutt.rinasaker.webapp.common
 import com.nimbusds.jose.JOSEObjectType
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-
-fun voidHttpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<Void>(mockOAuth2Server.httpHeaders)
-
-val MockOAuth2Server.httpHeaders: HttpHeaders
-    get() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.set("Authorization", "Bearer ${this.token}")
-        return headers
-    }
 
 val MockOAuth2Server.token: String
     get() = this


### PR DESCRIPTION
Closes #20

## Endringer

- Erstatt `@AutoConfigureTestRestTemplate` med `@AutoConfigureRestTestClient`
- Erstatt `TestRestTemplate` med `RestTestClient` (Spring Boot 4 standard)
- Oppdater `execute()` til å bruke `RestTestClient` sitt fluent API
- Fjern ubrukte `httpEntity`/`voidHttpEntity`/`httpHeaders`-hjelpere fra `HttpEntity.kt`